### PR TITLE
Add progress bar and enforce kw-only args

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is recommended to run the solver in a virtual environment:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install mlx
+pip install -r requirements.txt
 ```
 
 Run the solver with
@@ -24,3 +24,9 @@ python3 solver.py
 The script prints progress, saves `p1_strategy.json` and `p2_strategy.json` and
 reports the final expected value (EV) for both players along with the average
 bet for each card value.
+
+Run the tests with
+
+```bash
+pytest -q
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mlx
+numpy
+scipy
+tqdm

--- a/solver_test.py
+++ b/solver_test.py
@@ -43,5 +43,11 @@ def test_convergence_small_game():
     cards = mx.linspace(0, 1, 2)
     bets = mx.linspace(0, 1, 2)
     win_matrix = (cards[:, None] > cards[None, :]).astype(mx.float32)
-    value = compute_ev(p1, p2, cards, bets, win_matrix).item()
+    value = compute_ev(
+        p1_strategy=p1,
+        p2_strategy=p2,
+        cards=cards,
+        bets=bets,
+        win_matrix=win_matrix,
+    ).item()
     assert abs(value - target) <= 0.05


### PR DESCRIPTION
## Summary
- display CFR progress with tqdm
- enforce keyword-only args for `compute_ev` and adjust calls
- show sample run uses keywords for clarity
- document setup dependencies and list them in requirements.txt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a39378e08320bf3bf184e6f1e959