### PR TITLE
Ensure progress bar always shows nash distance

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -55,7 +55,10 @@ def solve(
     p2_regrets = mx.zeros((num_cards, num_bets - 1, 2))
     p2_strategy_total = mx.zeros_like(p2_regrets)
 
-    progress = tqdm(range(iterations))
+    initial_distance = float(
+        mx.maximum(p1_regrets, 0).sum() + mx.maximum(p2_regrets, 0).sum()
+    )
+    progress = tqdm(range(iterations), desc=f"\u0394N {initial_distance:.4f}")
     for i in progress:
         p1_strategy = regret_matching(p1_regrets)
         p2_strategy = regret_matching(p2_regrets)


### PR DESCRIPTION
## Summary
- initialize the tqdm progress bar with the initial Nash distance so it displays a description from the start

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a67027fc8320a8dbe50cb1156157