### PR TITLE
Ensure float32 dtype when building game

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -36,8 +36,10 @@ class GameTables:
 def _build_game(num_cards: int, num_bets: int, bet_max: float) -> GameTables:
     """Return lookup tables for a discretised game."""
 
-    cards = mx.linspace(0, 1, num_cards)
-    bets = bet_max * mx.linspace(0, 1, num_bets)
+    cards = mx.linspace(0, 1, num_cards, dtype=mx.float32)
+    bets = mx.array(bet_max, dtype=mx.float32) * mx.linspace(
+        0, 1, num_bets, dtype=mx.float32
+    )
     win_matrix = (cards[:, None] > cards[None, :]).astype(mx.float32)
     win_means = win_matrix.mean(axis=1)
     payoff_if_call = (


### PR DESCRIPTION
## Summary
- set explicit dtype in `_build_game` so that all generated values remain `float32`
- multiply bet linspace by `mx.array(bet_max, dtype=mx.float32)`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b0b9b3a883208ae804b6f1678646