### PR TITLE
Add device flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ pip install -r requirements.txt
 Run the solver with
 
 ```bash
-python3 solver.py
+python3 solver.py [--device cpu|gpu]
 ```
+The device flag is optional and defaults to running on the CPU.
 
 The script prints progress, saves `p1_strategy.json` and `p2_strategy.json` and
 reports the final expected value (EV) for both players along with the average

--- a/solver.py
+++ b/solver.py
@@ -16,10 +16,19 @@ and for every card value and bet it stores the probability of ``fold`` (index
 
 import json
 import math
+import argparse
 from dataclasses import dataclass
 
 from tqdm import tqdm
 import mlx.core as mx
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--device",
+    choices=["cpu", "gpu"],
+    help="Run computations on the selected device",
+)
 
 
 @dataclass
@@ -261,4 +270,11 @@ def solve(
 
 
 if __name__ == "__main__":
+    args = parser.parse_args()
+    if args.device:
+        try:
+            mx.set_default_device(mx.Device(args.device))
+        except TypeError:
+            mapping = {"cpu": mx.cpu, "gpu": mx.gpu}
+            mx.set_default_device(mx.Device(mapping[args.device]))
     solve(num_cards=21, num_bets=11, bet_max=1.0, iterations=1_000)

--- a/solver_test.py
+++ b/solver_test.py
@@ -4,6 +4,11 @@ import mlx.core as mx
 
 from solver import solve, compute_ev
 
+try:
+    mx.set_default_device(mx.Device("cpu"))
+except TypeError:
+    mx.set_default_device(mx.Device(mx.cpu))
+
 
 def analytic_solution_value() -> float:
     """Return the Nash value for the simple two-card game."""


### PR DESCRIPTION
## Summary
- allow selecting the execution device with `--device`
- document the new flag in the README
- pin tests to CPU so they run consistently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b0bc28fc83209276d5f3d27063aa